### PR TITLE
Fix sequence collision suffix placement

### DIFF
--- a/modules/saver.py
+++ b/modules/saver.py
@@ -4,6 +4,7 @@ import numpy as np
 import tifffile
 import folder_paths
 import logging
+import re
 from typing import Dict, Tuple, Optional, List
 import OpenImageIO as oiio
 from datetime import datetime
@@ -255,8 +256,44 @@ class SaverNode:
         
         tifffile.imwrite(path, data, photometric=photometric)
 
-    def get_unique_filepath(self, base_path: str) -> str:
-        """Get unique filepath with incremental counter"""
+    @staticmethod
+    def insert_suffix_before_frame(path: str, frame_token: str, suffix: str) -> str:
+        """Insert a suffix before a sequence frame token in a file path."""
+        if not frame_token or not suffix:
+            return path
+
+        dir_name = os.path.dirname(path)
+        base_name = os.path.basename(path)
+        name, ext = os.path.splitext(base_name)
+        frame_index = name.rfind(frame_token)
+        if frame_index < 0:
+            return os.path.join(dir_name, f"{name}{suffix}{ext}")
+
+        prefix = name[:frame_index]
+        rest = name[frame_index:]
+        if prefix and prefix[-1] in "._-":
+            separator = prefix[-1]
+            prefix = prefix[:-1]
+        else:
+            separator = "_"
+
+        return os.path.join(dir_name, f"{prefix}{suffix}{separator}{rest}{ext}")
+
+    @staticmethod
+    def replace_sequence_placeholder(filename: str, frame_number: int) -> Tuple[str, str]:
+        """Replace the first ####/### style placeholder and return filename plus frame token."""
+        match = re.search(r"#+", filename)
+        if not match:
+            frame_token = f"{frame_number:04d}"
+            return filename, frame_token
+
+        padding = len(match.group(0))
+        frame_token = f"{frame_number:0{padding}d}"
+        replaced = filename[:match.start()] + frame_token + filename[match.end():]
+        return replaced, frame_token
+
+    def get_unique_filepath(self, base_path: str, frame_token: Optional[str] = None) -> str:
+        """Get unique filepath with incremental counter."""
         if not os.path.exists(base_path):
             return base_path
         
@@ -266,7 +303,10 @@ class SaverNode:
         
         counter = 1
         while True:
-            new_path = os.path.join(dir_name, f"{name}_{counter}{ext}")
+            if frame_token:
+                new_path = self.insert_suffix_before_frame(base_path, frame_token, f"_{counter}")
+            else:
+                new_path = os.path.join(dir_name, f"{name}_{counter}{ext}")
             if not os.path.exists(new_path):
                 return new_path
             counter += 1
@@ -335,18 +375,24 @@ class SaverNode:
                 if is_sequence_mode and SequenceHandler.detect_sequence_pattern(filename):
                     # Sequence mode with #### pattern
                     frame_number = start_frame + (i * frame_step)
-                    sequence_filename = filename.replace('####', f'{frame_number:04d}')
-                    out_path = f"{os.path.join(os.path.dirname(base_path), sequence_filename)}{version_str}.{file_type}"
+                    sequence_filename, frame_token = self.replace_sequence_placeholder(filename, frame_number)
+                    out_path = f"{os.path.join(os.path.dirname(base_path), sequence_filename)}.{file_type}"
+                    if version_str:
+                        out_path = self.insert_suffix_before_frame(out_path, frame_token, version_str)
                 elif is_sequence_mode:
                     # Sequence mode without pattern - use frame numbers
                     frame_number = start_frame + (i * frame_step)
-                    out_path = f"{base_path}_{frame_number:04d}{version_str}.{file_type}"
+                    frame_token = f"{frame_number:04d}"
+                    out_path = f"{base_path}_{frame_token}.{file_type}"
+                    if version_str:
+                        out_path = self.insert_suffix_before_frame(out_path, frame_token, version_str)
                 else:
                     # Single mode - use index for multiple images
                     frame_str = f"_{i}" if len(images) > 1 else ""
                     out_path = f"{base_path}{version_str}{frame_str}.{file_type}"
+                    frame_token = None
                 
-                out_path = self.get_unique_filepath(out_path)
+                out_path = self.get_unique_filepath(out_path, frame_token=frame_token)
                 
                 # Save based on format
                 if file_type == "exr":

--- a/tests/test_saver_sequence_versioning.py
+++ b/tests/test_saver_sequence_versioning.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+
+def _install_runtime_stubs(output_dir: Path) -> None:
+    torch = types.ModuleType("torch")
+    torch.Tensor = object
+    sys.modules.setdefault("torch", torch)
+
+    tifffile = types.ModuleType("tifffile")
+    tifffile.imwrite = lambda *args, **kwargs: None
+    sys.modules.setdefault("tifffile", tifffile)
+
+    folder_paths = types.ModuleType("folder_paths")
+    folder_paths.get_output_directory = lambda: str(output_dir)
+    folder_paths.get_temp_directory = lambda: str(output_dir / "temp")
+    sys.modules["folder_paths"] = folder_paths
+
+    oiio = types.ModuleType("OpenImageIO")
+    oiio.HALF = "half"
+    oiio.FLOAT = "float"
+    oiio.UINT8 = "uint8"
+    oiio.UINT16 = "uint16"
+    oiio.ROI = lambda: None
+    oiio.geterror = lambda: "OpenImageIO stub"
+    oiio.ImageSpec = lambda *args, **kwargs: object()
+
+    class _ImageBuf:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def set_pixels(self, *args, **kwargs):
+            pass
+
+        def write(self, path):
+            Path(path).write_bytes(b"stub")
+            return True
+
+    oiio.ImageBuf = _ImageBuf
+    sys.modules.setdefault("OpenImageIO", oiio)
+
+    cv2 = types.ModuleType("cv2")
+    cv2.COLOR_RGB2BGR = 0
+    cv2.IMWRITE_JPEG_QUALITY = 1
+    cv2.IMWRITE_WEBP_QUALITY = 2
+    cv2.cvtColor = lambda data, code: data
+    cv2.imwrite = lambda path, data, options=None: Path(path).write_bytes(b"stub") or True
+    sys.modules.setdefault("cv2", cv2)
+
+
+def _load_saver_module(output_dir: Path):
+    root = Path(__file__).resolve().parents[1]
+    package = types.ModuleType("cocotools_io")
+    package.__path__ = [str(root)]
+    sys.modules["cocotools_io"] = package
+
+    modules_package = types.ModuleType("cocotools_io.modules")
+    modules_package.__path__ = [str(root / "modules")]
+    sys.modules["cocotools_io.modules"] = modules_package
+
+    _install_runtime_stubs(output_dir)
+    spec = importlib.util.spec_from_file_location(
+        "cocotools_io.modules.saver",
+        root / "modules" / "saver.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    module.generate_preview_for_comfyui = lambda *args, **kwargs: []
+    module.SaverNode.prepare_image = lambda self, image, save_as_grayscale: module.np.zeros((1, 1, 3), dtype=module.np.float32)
+    module.SaverNode.save_exr = lambda self, img, path, bit_depth, compression: Path(path).write_bytes(b"stub")
+    return module
+
+
+class SaverSequenceVersioningTests(unittest.TestCase):
+    def test_unique_sequence_counter_is_inserted_before_hash_frame(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            module = _load_saver_module(output_dir)
+            existing = output_dir / "shot.1001.exr"
+            existing.write_bytes(b"already here")
+
+            result = module.SaverNode().save_images(
+                images=[object(), object()],
+                file_path="",
+                filename="shot.####",
+                save_mode="sequence",
+                file_type="exr",
+                bit_depth=16,
+                start_frame=1001,
+                frame_step=1,
+            )
+
+        saved = [item["filename"] for item in result["ui"]["saved_files"]]
+        self.assertEqual(saved, ["shot_1.1001.exr", "shot.1002.exr"])
+
+    def test_unique_sequence_counter_is_inserted_before_generated_frame(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            module = _load_saver_module(output_dir)
+            existing = output_dir / "shot_0001.exr"
+            existing.write_bytes(b"already here")
+
+            result = module.SaverNode().save_images(
+                images=[object()],
+                file_path="",
+                filename="shot",
+                save_mode="sequence",
+                file_type="exr",
+                bit_depth=16,
+                start_frame=1,
+                frame_step=1,
+            )
+
+        saved = [item["filename"] for item in result["ui"]["saved_files"]]
+        self.assertEqual(saved, ["shot_1_0001.exr"])
+
+    def test_explicit_version_is_inserted_before_sequence_frame(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            module = _load_saver_module(Path(tmp))
+
+            result = module.SaverNode().save_images(
+                images=[object()],
+                file_path="",
+                filename="shot.####",
+                save_mode="sequence",
+                file_type="exr",
+                bit_depth=16,
+                use_versioning=True,
+                version=3,
+                start_frame=1001,
+                frame_step=1,
+            )
+
+        saved = [item["filename"] for item in result["ui"]["saved_files"]]
+        self.assertEqual(saved, ["shot_v003.1001.exr"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Move automatic filename collision suffixes before EXR/image sequence frame numbers, so an existing `shot.1001.exr` produces `shot_1.1001.exr` instead of breaking the sequence pattern.
- Apply the same before-frame placement to explicit saver versions in sequence mode, e.g. `shot_v003.1001.exr`.
- Add regression tests covering hash-pattern sequences, generated frame-number sequences, and explicit versioned sequences.

## Root cause

`get_unique_filepath()` always appended the collision counter after the full basename. For sequence outputs, that placed `_1` after the frame token, turning the generated filename into a non-sequence shape.

## Validation

- `/Applications/ComfyUI/venv/bin/python -m unittest discover -s tests`
- `/Applications/ComfyUI/venv/bin/python -m py_compile modules/saver.py tests/test_saver_sequence_versioning.py`
